### PR TITLE
Clear Mock storage after verifying call

### DIFF
--- a/Sources/Mimus/Mock.swift
+++ b/Sources/Mimus/Mock.swift
@@ -90,5 +90,7 @@ public extension Mock {
             testLocation: testLocation)
 
         TestLocation.internalTestLocation = nil
+
+        storage = []
     }
 }

--- a/Tests/MimusTests/MockTests.swift
+++ b/Tests/MimusTests/MockTests.swift
@@ -111,6 +111,16 @@ class MockTests: XCTestCase {
         XCTAssertEqual(fakeVerificationHandler.lastMismatchedArgumentsResults?.count, 2, "Expected verification handler to receive correct number of unmatched arguments")
     }
 
+    func testCorrectNumberOfMatchesAfterVeryfingTwoTimes() {
+        mockRecorder.recordCall(withIdentifier: "Fixture Identifier")
+        mockRecorder.verifyCall(withIdentifier: "Fixture Identifier")
+
+        mockRecorder.verifyCall(withIdentifier: "Fixture Identifier")
+
+        XCTAssertEqual(fakeVerificationHandler.lastMatchedResults?.count, 0, "Expected no matched result")
+        XCTAssertEqual(fakeVerificationHandler.lastMismatchedArgumentsResults?.count, 0, "Expected no mismatched result")
+    }
+
     func testCaptureArgument() {
         let argumentCaptor = CaptureArgumentMatcher()
 


### PR DESCRIPTION
Keeping storage between `verifyCall` calls could lead to false positive matching - We could capture a call with arguments, store it, and somewhere after first call verify against the same identifier and arguments, even if it wasn't called again. It could lead to hard to find bugs.